### PR TITLE
[BUGFIX] Avoid errors with Composer 1.x when testing `composer-update-check`

### DIFF
--- a/.github/workflows/tests-update-check.yaml
+++ b/.github/workflows/tests-update-check.yaml
@@ -40,6 +40,8 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: composer:v${{ matrix.composer-version }}
           coverage: none
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Define Composer cache
       - name: Get Composer cache directory
@@ -61,7 +63,9 @@ jobs:
 
       # Install update check
       - name: Install eliashaeussler/composer-update-check
-        run: composer require --prefer-source --no-progress "eliashaeussler/composer-update-check:dev-${{ github.event.inputs.update-check-branch }}#${{ github.event.inputs.update-check-sha }}@dev"
+        run: |
+          composer config repositories.composer-update-check vcs https://github.com/eliashaeussler/composer-update-check.git
+          composer require --prefer-source --no-progress "eliashaeussler/composer-update-check:dev-${{ github.event.inputs.update-check-branch }}#${{ github.event.inputs.update-check-sha }}@dev"
 
       # Run tests
       - name: Build coverage directory

--- a/.github/workflows/tests-update-check.yaml
+++ b/.github/workflows/tests-update-check.yaml
@@ -61,7 +61,7 @@ jobs:
 
       # Install update check
       - name: Install eliashaeussler/composer-update-check
-        run: composer require "eliashaeussler/composer-update-check:dev-${{ github.event.inputs.update-check-branch }}#${{ github.event.inputs.update-check-sha }}@dev"
+        run: composer require --prefer-source --no-progress "eliashaeussler/composer-update-check:dev-${{ github.event.inputs.update-check-branch }}#${{ github.event.inputs.update-check-sha }}@dev"
 
       # Run tests
       - name: Build coverage directory


### PR DESCRIPTION
When tests are triggered by the `composer-update-check` repository, the following error might occur:

> Could not find package eliashaeussler/composer-update-check in a version matching dev-bugfix/respect-platform-reqs#09c2220d1d8a776b520e041ca57931938b9e5c94@dev

This only happens for tests with Composer 1.x. It's probably because of the limited support for Composer 1.x on Packagist.

The following measures were taken to circumvent the problem:

- [x] Installing the `eliashaeussler/composer-update-check` requirement from source 
- [x] Register the source repository as Composer repository