### PR TITLE
[BUGFIX] Simplify test matrix configuration

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,28 +25,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        php-version: ["7.1", "7.2", "7.3", "7.4"]
+        composer-version: ["1", "2"]
         include:
-          - php-version: 7.1
-            composer-version: 1
-          - php-version: 7.1
-            composer-version: 2
-          - php-version: 7.2
-            composer-version: 1
-          - php-version: 7.2
-            composer-version: 2
-          - php-version: 7.3
-            composer-version: 1
-          - php-version: 7.3
-            composer-version: 2
-          - php-version: 7.4
-            composer-version: 1
-          - php-version: 7.4
-            composer-version: 2
           - php-version: 8.0
             composer-version: 1
           - php-version: 8.0
             composer-version: 2
-            coverage: 1
+            coverage: true
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,9 +28,9 @@ jobs:
         php-version: ["7.1", "7.2", "7.3", "7.4"]
         composer-version: ["1", "2"]
         include:
-          - php-version: 8.0
+          - php-version: "8.0"
             composer-version: 1
-          - php-version: 8.0
+          - php-version: "8.0"
             composer-version: 2
             coverage: true
     steps:


### PR DESCRIPTION
The test matrix has been simplified a lot. Additionally, the PHP "8.0" version is now resolved correctly in the job's label.