### PR TITLE
[BUGFIX] Run CGL and Tests workflows only on develop and main on push

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -2,7 +2,8 @@ name: CGL
 on:
   push:
     branches:
-      - '**'
+      - main
+      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,8 @@ name: Tests
 on:
   push:
     branches:
-      - '**'
+      - main
+      - develop
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
With this PR, the CGL and Tests workflows only run on

- develop
- main

on push. This avoids concurrent workflow runs for push & PR on all other branches than the mentioned ones.