### PR TITLE
[BUGFIX] Require Composer >= 1.8.5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: composer:v${{ matrix.composer-version }}
+          tools: composer:v2
           coverage: pcov
 
       # Define Composer cache
@@ -61,7 +61,11 @@ jobs:
 
       # Install dependencies
       - name: Install Composer and dependencies
-        run: composer require --dev --no-progress "composer/composer:^${{ matrix.composer-version }}"
+        run: |
+          composer config platform.composer-plugin-api "${{ matrix.composer-version }}.99"
+          composer config platform.composer-runtime-api "${{ matrix.composer-version }}.99"
+          composer update --no-progress --with "composer/composer:^${{ matrix.composer-version }}"
+          composer self-update --${{ matrix.composer-version }}
 
       # Run tests
       - name: Build coverage directory
@@ -123,7 +127,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: composer:v${{ matrix.composer-version }}
+          tools: composer:v2
           coverage: none
 
       # Define Composer cache
@@ -141,7 +145,11 @@ jobs:
 
       # Install dependencies
       - name: Install Composer and dependencies
-        run: composer require --dev --no-progress --prefer-lowest "composer/composer:^${{ matrix.composer-version }}"
+        run: |
+          composer config platform.composer-plugin-api "${{ matrix.composer-version }}.99"
+          composer config platform.composer-runtime-api "${{ matrix.composer-version }}.99"
+          composer update --no-progress --prefer-lowest --with "composer/composer:^${{ matrix.composer-version }}"
+          composer self-update --${{ matrix.composer-version }}
 
       # Run tests
       - name: Build coverage directory

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "symfony/mime": ">= 4.4 < 7.0"
   },
   "require-dev": {
-    "composer/composer": "^1.0 || ^2.0",
+    "composer/composer": "^1.8.5 || ^2.0",
     "ergebnis/composer-normalize": "^2.8",
     "friendsofphp/php-cs-fixer": ">= 2.17 < 4.0",
     "php-http/mock-client": "^1.0",


### PR DESCRIPTION
Composer versions < 1.8.5 are erroneous with PHP 7.4. Therefore, the `composer/composer` dev-dependency has now been changed to `^1.8.5 || ^2.0`.