### PR TITLE
[TASK] Drop support for `develop` branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       interval: daily
     commit-message:
       prefix: '[TASK]'
-    target-branch: develop
     labels:
       - dependencies
     open-pull-requests-limit: 10

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - '**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release
 
-[Unreleased]: https://github.com/eliashaeussler/composer-update-reporter/compare/1.3.0...develop
+[Unreleased]: https://github.com/eliashaeussler/composer-update-reporter/compare/1.3.0...main
 [1.3.0]: https://github.com/eliashaeussler/composer-update-reporter/compare/1.2.1...1.3.0
 [1.2.1]: https://github.com/eliashaeussler/composer-update-reporter/compare/1.2.0...1.2.1
 [1.2.0]: https://github.com/eliashaeussler/composer-update-reporter/compare/1.1.2...1.2.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Composer update reporter plugin
 
-[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-reporter/branch/develop/graph/badge.svg?token=4GZI1QWP5X)](https://codecov.io/gh/eliashaeussler/composer-update-reporter)
+[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-reporter/branch/main/graph/badge.svg?token=4GZI1QWP5X)](https://codecov.io/gh/eliashaeussler/composer-update-reporter)
 [![Maintainability](https://api.codeclimate.com/v1/badges/06d55184455feeee3652/maintainability)](https://codeclimate.com/github/eliashaeussler/composer-update-reporter/maintainability)
 [![Tests](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/tests.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/tests.yaml)
 [![CGL](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/cgl.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/cgl.yaml)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ hide:
 - toc
 ---
 
-[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-reporter/branch/develop/graph/badge.svg?token=4GZI1QWP5X)](https://codecov.io/gh/eliashaeussler/composer-update-reporter)
+[![Coverage](https://codecov.io/gh/eliashaeussler/composer-update-reporter/branch/main/graph/badge.svg?token=4GZI1QWP5X)](https://codecov.io/gh/eliashaeussler/composer-update-reporter)
 [![Maintainability](https://api.codeclimate.com/v1/badges/06d55184455feeee3652/maintainability)](https://codeclimate.com/github/eliashaeussler/composer-update-reporter/maintainability)
 [![Tests](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/tests.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/tests.yaml)
 [![CGL](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/cgl.yaml/badge.svg)](https://github.com/eliashaeussler/composer-update-reporter/actions/workflows/cgl.yaml)


### PR DESCRIPTION
This PR drops support for the `develop` branch. The `main` branch will be used as main branch in the future.